### PR TITLE
switch helm charts for confluent kafka platform

### DIFF
--- a/datetime-injector-app/app.py
+++ b/datetime-injector-app/app.py
@@ -9,14 +9,14 @@ app = Flask(__name__)
 
 producer_conf = {
     # 'bootstrap.servers': 'localhost:9092',
-    'bootstrap.servers': 'my-kafka-service:9092',
+    'bootstrap.servers': 'my-confluent-cp-kafka:9092',
     'client.id': socket.gethostname()
 }
 p = Producer(producer_conf)
 
 consumer_conf = {
     # 'bootstrap.servers': 'localhost:9092',
-    'bootstrap.servers': "my-kafka-service:9092",
+    'bootstrap.servers': "my-confluent-cp-kafka:9092",
     'group.id': 'mygroup',
     'client.id': socket.gethostname(),
     'enable.auto.commit': True,

--- a/kubernetes/deployments/datetime-injector-app.yml
+++ b/kubernetes/deployments/datetime-injector-app.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: datetime-injector-app
-        image: datetime-injector-app:0.2
+        image: datetime-injector-app:0.3
         ports:
         - containerPort: 5000
         resources:

--- a/kubernetes/deployments/kafka-client.yml
+++ b/kubernetes/deployments/kafka-client.yml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kafka-client
+  namespace: default
+spec:
+  containers:
+  - name: kafka-client
+    image: confluentinc/cp-enterprise-kafka:5.5.0
+    command:
+      - sh
+      - -c
+      - "exec tail -f /dev/null"
+    resources:
+      requests:
+        memory: "32Mi"
+        cpu: "200m"
+      limits:
+        memory: "64Mi"
+        cpu: "250m"


### PR DESCRIPTION
- pointed app to confluent kafka-service for offloading data to redis via kafka connect redis-sink-connector
- added kafka-client deployment for testing topic management